### PR TITLE
got health insurance info to show in jobs_table, in review screen, and...

### DIFF
--- a/docassemble/VT813/data/questions/VT_813.yml
+++ b/docassemble/VT813/data/questions/VT_813.yml
@@ -2362,7 +2362,7 @@ question: |
 subquestion: |
   You can look back 12 months for these expenses. That will give an accurate picture of how much the expenses really are.
 
-  If you have kids and already answered questions about expenses for children of your relationship with ${ other_party[0] }, do **not** include those child expenses here.
+  If you have kids and already answered questions about expenses for children of your relationship with ${ other_parties[0] }, do **not** include those child expenses here.
   
   % if monthly_debt_payment > 0:
   You said that you make these monthly debt payments:
@@ -4065,14 +4065,22 @@ attachments:
           
       - "health_insurance_family_cost": |
           % for job in jobs:
+          % if job.healthcare_available:
           ${ round(job.health_insurance_family_cost,2) }
+          % endif
           % endfor
-
-
       - "health_insurance_2_person_cost": |
-          ${ round(jobs.total_other_attribute(source='', attribute='health_insurance_2_person_cost'),2) } 
+          % for job in jobs:
+          % if job.healthcare_available:
+          ${ round(job.health_insurance_2_person_cost,2) }
+          % endif
+          % endfor
       - "health_insurance_single_person_cost": |
-          ${ round(jobs.total_other_attribute(source='', attribute='health_insurance_single_person_cost'),2) } 
+          % for job in jobs:
+          % if job.healthcare_available:
+          ${ round(job.health_insurance_2_person_cost,2) }
+          % endif
+          % endfor
       - "health_insurance_kids_enrolled_yes": |
           ${ jobs.kids_enrolled } 
       - "health_insurance_kids_enrolled_no": |


### PR DESCRIPTION
…now trying attachm. code --> for job in jobs ${ round(job.health_insurance_family_cost,2) }

fix #101 

@tobyfey The health insurance costs are not showing up on page 4 of the PDF. I got them to show in the jobs_table and a mention of health insurance in the jobs section of the review screen. And I tried a piece of code in the attachment block, but I think you need to figure out how to get the costs to show up there. Could you work on that part for this branch?

One thing to ponder: What if I have 2 jobs that offer health insurance. Which one will I list? I guess I'd list the prices for the plan that I enrolled in. But what if I haven't enrolled in either? Just pick one?