### PR TITLE
made children_income.parents variable

### DIFF
--- a/docassemble/VT813/data/questions/VT_813.yml
+++ b/docassemble/VT813/data/questions/VT_813.yml
@@ -412,6 +412,10 @@ code: |
     for income in child.income:
       children_income.append(income)
       children_income[-1].name = child.name
+      if not defined('children_income.parents'):
+        children_income.parents = income.parent
+      elif income.parent not in children_income.parents:
+        children_income.parents = children_income.parents + " & " + income.parent 
   children_income.gathered = True
 ---
 id: other children complete
@@ -4748,7 +4752,7 @@ attachments:
       - "childrens_income_other_benefit_monthly_amount": |
           ${ currency(children_income.total(source=['other'], times_per_year=12),symbol='') } 
       - "parent_name_gets_children_benefits": |
-          ${ children_income[0].parent } 
+          ${ children_income.parents } 
       - "users1_assets_real_estate_primary_res_lender": |
           ${ primary_residence_loans.matches(source=['primary'])[0].lender } 
       - "users1_assets_real_estate_primary_res_amount_owed": |


### PR DESCRIPTION
fix #186 

now when children_income is gathered, it creates a variable for children_income.parents, which is a string that will contain one or both of the parents names.  it is recomputed every time children_income is recomputed, which is any time shared_children is edited 